### PR TITLE
Fix NullPointerException

### DIFF
--- a/extension-push/src/java/com/defold/push/LocalNotificationReceiver.java
+++ b/extension-push/src/java/com/defold/push/LocalNotificationReceiver.java
@@ -26,8 +26,10 @@ public class LocalNotificationReceiver extends BroadcastReceiver {
             Push.getInstance().onLocalPush(context, extras.getString("payload"), id, false);
         } else {
             Notification notification = intent.getParcelableExtra(context.getPackageName() + Push.DEFOLD_NOTIFICATION);
-            nm = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-            nm.notify(id, notification);
+            if (notification != null) {
+                nm = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+                nm.notify(id, notification);
+            }
         }
 
     }

--- a/extension-push/src/java/com/defold/push/Push.java
+++ b/extension-push/src/java/com/defold/push/Push.java
@@ -259,15 +259,15 @@ public class Push {
         context.deleteFile(createLocalPushNotificationPath(uid));
     }
 
-    private Notification getLocalNotification(final Activity activity, Bundle extras, int uid) {
-        Intent new_intent = new Intent(activity.getApplicationContext(), PushDispatchActivity.class).setAction(Push.ACTION_FORWARD_PUSH);
+    private Notification getLocalNotification(final Context appContext, Bundle extras, int uid) {
+        Intent new_intent = new Intent(appContext, PushDispatchActivity.class).setAction(Push.ACTION_FORWARD_PUSH);
         new_intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
         new_intent.putExtras(extras);
-        PendingIntent contentIntent = PendingIntent.getActivity(activity.getApplicationContext(), uid, new_intent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_ONE_SHOT);
+        PendingIntent contentIntent = PendingIntent.getActivity(appContext, uid, new_intent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_ONE_SHOT);
 
-        ApplicationInfo info = activity.getApplicationInfo();
+        ApplicationInfo info = appContext.getApplicationInfo();
 
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(activity.getApplicationContext(), Push.NOTIFICATION_CHANNEL_ID)
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(appContext, Push.NOTIFICATION_CHANNEL_ID)
             .setContentTitle(extras.getString("title"))
             .setContentText(extras.getString("message"))
             .setContentIntent(contentIntent)
@@ -292,7 +292,7 @@ public class Push {
 
         try {
             // Get bitmap for large icon resource
-            PackageManager pm = activity.getPackageManager();
+            PackageManager pm = appContext.getPackageManager();
             Resources resources = pm.getResourcesForApplication(info);
             Bitmap largeIconBitmap = BitmapFactory.decodeResource(resources, largeIconId);
 
@@ -332,7 +332,9 @@ public class Push {
         if (am == null) {
             am = (AlarmManager) activity.getSystemService(activity.ALARM_SERVICE);
         }
-        Intent intent = new Intent(activity.getApplicationContext(), LocalNotificationReceiver.class);
+
+        Context appContext = activity.getApplicationContext();
+        Intent intent = new Intent(appContext, LocalNotificationReceiver.class);
 
         Bundle extras = new Bundle();
         String packageName = activity.getPackageName();
@@ -340,14 +342,14 @@ public class Push {
         int iconLarge = activity.getResources().getIdentifier("push_icon_large", "drawable", packageName);
         putValues(extras, uid, title, message, payload, timestampMillis, priority, iconSmall, iconLarge);
 
-        storeLocalPushNotification(activity.getApplicationContext(), uid, extras);
+        storeLocalPushNotification(appContext, uid, extras);
 
         intent.putExtras(extras);
         intent.setAction("uid" + uid);
-        intent.putExtra(packageName + DEFOLD_NOTIFICATION, getLocalNotification(activity, extras, uid));
+        intent.putExtra(packageName + DEFOLD_NOTIFICATION, getLocalNotification(appContext, extras, uid));
 
 
-        PendingIntent pendingIntent = PendingIntent.getBroadcast(activity, 0, intent, PendingIntent.FLAG_ONE_SHOT);
+        PendingIntent pendingIntent = PendingIntent.getBroadcast(appContext, 0, intent, PendingIntent.FLAG_ONE_SHOT);
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 am.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, timestampMillis, pendingIntent);

--- a/extension-push/src/java/com/defold/push/Push.java
+++ b/extension-push/src/java/com/defold/push/Push.java
@@ -332,7 +332,7 @@ public class Push {
         if (am == null) {
             am = (AlarmManager) activity.getSystemService(activity.ALARM_SERVICE);
         }
-        Intent intent = new Intent(activity, LocalNotificationReceiver.class);
+        Intent intent = new Intent(activity.getApplicationContext(), LocalNotificationReceiver.class);
 
         Bundle extras = new Bundle();
         String packageName = activity.getPackageName();
@@ -340,7 +340,7 @@ public class Push {
         int iconLarge = activity.getResources().getIdentifier("push_icon_large", "drawable", packageName);
         putValues(extras, uid, title, message, payload, timestampMillis, priority, iconSmall, iconLarge);
 
-        storeLocalPushNotification(activity, uid, extras);
+        storeLocalPushNotification(activity.getApplicationContext(), uid, extras);
 
         intent.putExtras(extras);
         intent.setAction("uid" + uid);

--- a/extension-push/src/java/com/defold/push/Push.java
+++ b/extension-push/src/java/com/defold/push/Push.java
@@ -273,6 +273,8 @@ public class Push {
             .setContentIntent(contentIntent)
             .setPriority(extras.getInt("priority"));
 
+        builder.getExtras().putInt("uid", uid);
+
         // Find icons, if they were supplied
         int smallIconId = extras.getInt("smallIcon");
         int largeIconId = extras.getInt("largeIcon");

--- a/extension-push/src/java/com/defold/push/Push.java
+++ b/extension-push/src/java/com/defold/push/Push.java
@@ -260,14 +260,14 @@ public class Push {
     }
 
     private Notification getLocalNotification(final Activity activity, Bundle extras, int uid) {
-        Intent new_intent = new Intent(activity, PushDispatchActivity.class).setAction(Push.ACTION_FORWARD_PUSH);
+        Intent new_intent = new Intent(activity.getApplicationContext(), PushDispatchActivity.class).setAction(Push.ACTION_FORWARD_PUSH);
         new_intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
         new_intent.putExtras(extras);
-        PendingIntent contentIntent = PendingIntent.getActivity(activity, uid, new_intent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_ONE_SHOT);
+        PendingIntent contentIntent = PendingIntent.getActivity(activity.getApplicationContext(), uid, new_intent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_ONE_SHOT);
 
         ApplicationInfo info = activity.getApplicationInfo();
 
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(activity, Push.NOTIFICATION_CHANNEL_ID)
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(activity.getApplicationContext(), Push.NOTIFICATION_CHANNEL_ID)
             .setContentTitle(extras.getString("title"))
             .setContentText(extras.getString("message"))
             .setContentIntent(contentIntent)


### PR DESCRIPTION
We tested and found that some crashes were related to the activity/context issue. 

But here is code from [Android code](https://cs.android.com/android/platform/superproject/+/android-11.0.0_r48:frameworks/base/core/java/android/app/Notification.java;l=3054;bpv=0;bpt=1#:~:text=3053-,3054,-3055) in a place where extension crashes with NullPointer: 
```
  public static void addFieldsFromContext(ApplicationInfo ai, Notification notification) {
        notification.extras.putParcelable(EXTRA_BUILDER_APPLICATION_INFO, ai);
    }
```

```
java.lang.RuntimeException: 
  at android.app.ActivityThread.handleReceiver (ActivityThread.java:4487)
  at android.app.ActivityThread.access$1500 (ActivityThread.java:301)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2169)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loop (Looper.java:246)
  at android.app.ActivityThread.main (ActivityThread.java:8595)
  at java.lang.reflect.Method.invoke (Native Method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:602)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1130)
Caused by: java.lang.NullPointerException: 
  at android.app.Notification.addFieldsFromContext (Notification.java:3114)
  at android.app.Notification.addFieldsFromContext (Notification.java:3107)
  at android.app.NotificationManager.fixNotification (NotificationManager.java:610)
  at android.app.NotificationManager.notifyAsUser (NotificationManager.java:601)
  at android.app.NotificationManager.notify (NotificationManager.java:535)
  at android.app.NotificationManager.notify (NotificationManager.java:511)
  at com.defold.push.LocalNotificationReceiver.onReceive (LocalNotificationReceiver.java:30)
  at android.app.ActivityThread.handleReceiver (ActivityThread.java:4478)
```

It is possible only id `notification` is null or `extras` is null, I covered both cases in this fix

    
    