### PR TITLE
Do not convert the entire NSDictionary to json

### DIFF
--- a/extension-push/src/push_ios.mm
+++ b/extension-push/src/push_ios.mm
@@ -110,7 +110,7 @@ static const char* ObjCToJson(id obj)
     dmPush::Command cmd;
     cmd.m_Callback = g_Push.m_Listener;
     cmd.m_Command = dmPush::COMMAND_TYPE_LOCAL_MESSAGE_RESULT;
-    cmd.m_Result = ObjCToJson(notification.userInfo);
+    cmd.m_Result = strdup([[notification.userInfo valueForKey: @"payload"] UTF8String]);
     cmd.m_WasActivated = wasActivated;
 
     if (g_Push.m_Listener) {


### PR DESCRIPTION
The received userinfo contains both the notification id and the payload string. On iOS we incorrectly converted this to JSON and returned it to the listen, when we in fact should only return the payload (which is already in JSON format).

Fixes #43 