### PR TITLE
Avoid icon serialization

### DIFF
--- a/extension-push/manifests/android/build.gradle
+++ b/extension-push/manifests/android/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
   // https://firebase.google.com/docs/android/setup#available-libraries
   compile 'com.google.firebase:firebase-messaging:21.0.0'
-
+  implementation "androidx.core:core:1.5.0"
 }


### PR DESCRIPTION
Resource ID may be changed between bundles. In this case deserelisation of the notification will crash.
So, notification should be re-created and icon set.